### PR TITLE
fix(fake-namespace): remove

### DIFF
--- a/packages/webseal/src/App.js
+++ b/packages/webseal/src/App.js
@@ -85,7 +85,7 @@ const Editor = () => {
       }
       const sealedSecret = await getSealedSecret({
         pemKey,
-        namespace: data.namespace || "some-namespace",
+        namespace: data.namespace || null,
         name: data.name || "some-secret-name",
         scope: data.scope,
         values,


### PR DESCRIPTION
as kube-workflow doesn't support anymore fake namespace (because automatic replacement of them is incompatible with templating and we allow templating in same folder than where we put sealed secrets), so I think it's better to purpose null namespace (this will be automatically replaced by kube-workflow (last upgrade))